### PR TITLE
Avoid the use of external CDN sources on Tool labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It currently supports the following triggers:
  - Page added to category
  - Page updated in category
  - Updates to an item
+ - Birthday of persons today
 
 # [WIP] Deploying to Wikimedia Labs
 

--- a/ifttt/__init__.py
+++ b/ifttt/__init__.py
@@ -28,3 +28,4 @@ sys.setdefaultencoding('utf-8')
 
 from .core import app
 from flask import Flask
+from flask_material import Material

--- a/ifttt/core.py
+++ b/ifttt/core.py
@@ -26,7 +26,7 @@ import flask
 from urllib import urlencode
 from flask import request, render_template, g
 from flask import redirect, url_for
-from flask_material import Material 
+import flask_material
 
 from .utils import snake_case
 from .triggers import (ArticleOfTheDay,
@@ -62,7 +62,7 @@ ALL_TRIGGERS = [ArticleOfTheDay,
                 PopularPersonsBirthday]
 
 app = flask.Flask(__name__)
-material = Material(app)
+material = flask_material.Material(app)
 # Load default config first
 app.config.from_pyfile('../default.cfg', silent=True)
 # Override defaults if ifttt.cfg is present

--- a/ifttt/core.py
+++ b/ifttt/core.py
@@ -29,17 +29,17 @@ from flask import redirect, url_for
 from flask_material import Material
 
 from .utils import snake_case
-from .triggers import (ArticleOfTheDay,
-                       PictureOfTheDay,
-                       WordOfTheDay,
-                       ArticleRevisions,
-                       UserRevisions,
-                       NewArticle,
-                       NewHashtag,
-                       NewCategoryMember,
-                       CategoryMemberRevisions,
-                       ItemRevisions,
-                       PopularPersonsBirthday)
+from .triggers import (PictureOfTheDay,
+                      ArticleOfTheDay,
+                      WordOfTheDay,
+                      ArticleRevisions,
+                      UserRevisions,
+                      NewArticle,
+                      NewHashtag,
+                      NewCategoryMember,
+                      CategoryMemberRevisions,
+                      ItemRevisions,
+                      PopularPersonsBirthday)
 
 import logging
 LOG_FILE = 'ifttt.log'
@@ -49,8 +49,8 @@ logging.basicConfig(filename=LOG_FILE,
                     level=logging.DEBUG)
 
 
-ALL_TRIGGERS = [ArticleOfTheDay,
-                PictureOfTheDay,
+ALL_TRIGGERS = [PictureOfTheDay,
+                ArticleOfTheDay,
                 WordOfTheDay,
                 ArticleRevisions,
                 UserRevisions,

--- a/ifttt/core.py
+++ b/ifttt/core.py
@@ -26,7 +26,7 @@ import flask
 from urllib import urlencode
 from flask import request, render_template, g
 from flask import redirect, url_for
-import flask_material
+from flask_material import Material
 
 from .utils import snake_case
 from .triggers import (ArticleOfTheDay,
@@ -62,7 +62,7 @@ ALL_TRIGGERS = [ArticleOfTheDay,
                 PopularPersonsBirthday]
 
 app = flask.Flask(__name__)
-material = flask_material.Material(app)
+material = Material(app)
 # Load default config first
 app.config.from_pyfile('../default.cfg', silent=True)
 # Override defaults if ifttt.cfg is present

--- a/ifttt/templates/article_of_the_day.xml
+++ b/ifttt/templates/article_of_the_day.xml
@@ -14,7 +14,7 @@
                 </image>
                 <description>{{feeds.summary}}</description>
                 <title>{{feeds.title}}</title>
-                <link>{{feeds.url}}</link>
+                <url>{{feeds.url}}</url>
             </item>
         {% endfor %}
     </channel>

--- a/ifttt/templates/article_revisions.xml
+++ b/ifttt/templates/article_revisions.xml
@@ -7,7 +7,7 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.comment}}</comment>
+                <description>{{feeds.comment}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
                 <image>
@@ -15,7 +15,7 @@
                 </image>
                 <size>{{feeds.size}}</size>
                 <title>{{feeds.title}}</title>
-                <link>{{feeds.url}}</link>
+                <url>{{feeds.url}}</url>
                 <user>{{feeds.user}}</user>
             </item>
         {% endfor %}

--- a/ifttt/templates/category_member_revisions.xml
+++ b/ifttt/templates/category_member_revisions.xml
@@ -7,13 +7,13 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.comment}}</comment>
+                <description>{{feeds.comment}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
                 <image>
                     <url>{{feeds.media_url}}</url>
                 </image>
-                <description>Size: {{feeds.size}}</description>
+                <size>Size: {{feeds.size}}</size>
                 <title>{{feeds.title}}</title>
                 <url>{{feeds.url}}</url>
                 <guid>{{feeds.user}}</guid>

--- a/ifttt/templates/error_pages/404.html
+++ b/ifttt/templates/error_pages/404.html
@@ -49,7 +49,7 @@
     </div>
 </div>
 
-<!--    JAVASCRIPT DEPENENCIES      -->
+<!-- JAVASCRIPT DEPENENCIES -->
 
 <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
@@ -63,7 +63,7 @@
 {% block footer %}
 <div class="navbar navbar-default" id="footer">
     <div class="navbar-header">
-        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick under the supervision of Wikimedia Foundation Inc</h3>
+        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
     </div>
 </div>
 {% endblock %}

--- a/ifttt/templates/error_pages/404.html
+++ b/ifttt/templates/error_pages/404.html
@@ -4,12 +4,11 @@
 
 {% block head %}
     {{ super() }}
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link href="http://materialdesignblog.com/Material-Design-Flipper/material/css/ripples.min.css" rel="stylesheet">
     <link href="http://materialdesignblog.com/Material-Design-Flipper/material/css/material-wfont.min.css" rel="stylesheet">
-
     <link href="http://materialdesignblog.com/Material-Design-Flipper/css/flipper.css" rel="stylesheet">
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <style type="text/css">
         #hover-card {
             text-decoration: none;
@@ -50,11 +49,9 @@
 </div>
 
 <!-- JAVASCRIPT DEPENENCIES -->
-
-<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/ripples.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/material.min.js"></script>
 
@@ -63,7 +60,7 @@
 {% block footer %}
 <div class="navbar navbar-default" id="footer">
     <div class="navbar-header">
-        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
+        <h3 style="position: relative;left: 180px;color: white;">(c) All rights reserved 2017 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
     </div>
 </div>
 {% endblock %}

--- a/ifttt/templates/error_pages/500.html
+++ b/ifttt/templates/error_pages/500.html
@@ -4,12 +4,11 @@
 
 {% block head %}
     {{ super() }}
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link href="http://materialdesignblog.com/Material-Design-Flipper/material/css/ripples.min.css" rel="stylesheet">
     <link href="http://materialdesignblog.com/Material-Design-Flipper/material/css/material-wfont.min.css" rel="stylesheet">
-
     <link href="http://materialdesignblog.com/Material-Design-Flipper/css/flipper.css" rel="stylesheet">
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <style type="text/css">
         #hover-card {
             text-decoration: none;
@@ -50,11 +49,9 @@
 </div>
 
 <!-- JAVASCRIPT DEPENENCIES -->
-
-<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/ripples.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/material.min.js"></script>
 
@@ -63,7 +60,7 @@
 {% block footer %}
 <div class="navbar navbar-default" id="footer">
     <div class="navbar-header">
-        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
+        <h3 style="position: relative;left: 180px;color: white;">(c) All rights reserved 2017 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
     </div>
 </div>
 {% endblock %}

--- a/ifttt/templates/error_pages/500.html
+++ b/ifttt/templates/error_pages/500.html
@@ -42,14 +42,14 @@
                 <div class="flip-card active-card">
                     <div class="card label-info" style="background-color: #7ec0ee !important;color: white; height: 450px;">
                         <h1 align="center"><br />Page not found</h1>
-                        <h6 align="center">404</h6>
+                        <h6 align="center">500</h6>
                     </div>
                 </div>
             </div>
     </div>
 </div>
 
-<!--    JAVASCRIPT DEPENENCIES      -->
+<!-- JAVASCRIPT DEPENENCIES -->
 
 <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
@@ -63,7 +63,7 @@
 {% block footer %}
 <div class="navbar navbar-default" id="footer">
     <div class="navbar-header">
-        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick under the supervision of Wikimedia Foundation Inc</h3>
+        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
     </div>
 </div>
 {% endblock %}

--- a/ifttt/templates/index.html
+++ b/ifttt/templates/index.html
@@ -61,12 +61,11 @@
     </div>
 </div>
 
-<!--    JAVASCRIPT DEPENENCIES      -->
+<!-- JAVASCRIPT DEPENENCIES -->
 
 <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/ripples.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/material.min.js"></script>
 <script>
@@ -80,7 +79,7 @@
 {% block footer %}
 <div class="navbar navbar-default" id="footer">
     <div class="navbar-header">
-        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick under the supervision of Wikimedia Foundation Inc</h3>
+        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
     </div>
 </div>
 {% endblock %}

--- a/ifttt/templates/index.html
+++ b/ifttt/templates/index.html
@@ -4,12 +4,11 @@
 
 {% block head %}
     {{ super() }}
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link href="http://materialdesignblog.com/Material-Design-Flipper/material/css/ripples.min.css" rel="stylesheet">
     <link href="http://materialdesignblog.com/Material-Design-Flipper/material/css/material-wfont.min.css" rel="stylesheet">
-
     <link href="http://materialdesignblog.com/Material-Design-Flipper/css/flipper.css" rel="stylesheet">
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <style type="text/css">
         #hover-card {
             text-decoration: none;
@@ -62,10 +61,9 @@
 </div>
 
 <!-- JAVASCRIPT DEPENENCIES -->
-
-<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="//tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/ripples.min.js"></script>
 <script src="http://materialdesignblog.com/Material-Design-Flipper/material/js/material.min.js"></script>
 <script>
@@ -79,7 +77,7 @@
 {% block footer %}
 <div class="navbar navbar-default" id="footer">
     <div class="navbar-header">
-        <h3 style="position: relative;left: 110px;color: white;">(c) All rights reserved 2016 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
+        <h3 style="position: relative;left: 180px;color: white;">(c) All rights reserved 2017 | Developed by Alangi Derick, supervised by Wikimedia Foundation</h3>
     </div>
 </div>
 {% endblock %}

--- a/ifttt/templates/item_revisions.xml
+++ b/ifttt/templates/item_revisions.xml
@@ -7,13 +7,13 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.comment}}</comment>
+                <description>{{feeds.comment}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
-                <description>Size: {{feeds.size}}</description>
+                <size>Size: {{feeds.size}}</size>
                 <url>{{feeds.url}}</url>
                 <title>{{feeds.item}}</title>
-                <guid>{{feeds.user}}</guid>
+                <user>{{feeds.user}}</user>
             </item>
         {% endfor %}
     </channel>

--- a/ifttt/templates/new_article.xml
+++ b/ifttt/templates/new_article.xml
@@ -7,7 +7,7 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.comment}}</comment>
+                <description>{{feeds.comment}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
                 <size>{{feeds.size}}</size>

--- a/ifttt/templates/new_category_member.xml
+++ b/ifttt/templates/new_category_member.xml
@@ -7,7 +7,7 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.category}}</comment>
+                <description>{{feeds.category}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
                 <image>

--- a/ifttt/templates/new_hashtag.xml
+++ b/ifttt/templates/new_hashtag.xml
@@ -7,14 +7,14 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.comment}}</comment>
+                <description>{{feeds.comment}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
-                <comment>{{feeds.input_hashtag}}</comment>
+                <description>{{feeds.input_hashtag}}</description>
                 <image>
                     <url>{{feeds.media_url}}</url>
                 </image>
-                <comment>{{feeds.return_hashtags}}</comment>
+                <description>{{feeds.return_hashtags}}</description>
                 <size>{{feeds.size}}</size>
                 <title>{{feeds.title}}</title>
                 <url>{{feeds.url}}</url>

--- a/ifttt/templates/popular_persons_birthday.xml
+++ b/ifttt/templates/popular_persons_birthday.xml
@@ -10,10 +10,10 @@
                 <title>{{feeds.user|e}}</title>
                 <year>Year of birth: {{feeds.year|e}}</year>
                 <age>{{feeds.age|e}} years old</age>
-                <comment>{{feeds.user|e}} was born in the year {{feeds.year|e}} and is celebrating {{feeds.age|e}} year birthday anniversary</comment>
+                <description>{{feeds.user|e}} was born in the year {{feeds.year|e}} and is celebrating {{feeds.age|e}} year birthday anniversary</description>
                 <date>{{feeds.date[0:10]|e}}</date>
                 <property>{{feeds.property|e}}</property>
-                <item>{{feeds.item|e}}</item>
+                <itemId>{{feeds.item|e}}</itemId>
             </item>
         {% endfor %}
     </channel>

--- a/ifttt/templates/user_revisions.xml
+++ b/ifttt/templates/user_revisions.xml
@@ -7,16 +7,16 @@
         <language>en-us</language>
         {% for feeds in data %}
             <item>
-                <comment>{{feeds.comment}}</comment>
+                <description>{{feeds.comment}}</description>
                 <pubDate>{{feeds.created_at}}</pubDate>
                 <date>{{feeds.date}}</date>
                 <image>
                     <url>{{feeds.media_url}}</url>
                 </image>
-                <description>Size: {{feeds.size}}</description>
+                <size>Size: {{feeds.size}}</size>
                 <url>{{feeds.url}}</url>
                 <title>{{feeds.title}}</title>
-                <guid>{{feeds.user}}</guid>
+                <user>{{feeds.user}}</user>
             </item>
         {% endfor %}
     </channel>

--- a/toolinfo.json
+++ b/toolinfo.json
@@ -1,6 +1,6 @@
 {
-    "name" : "Wikipedia & Wikidata RSS Feeds",
-    "title" : "Featured content on Wikimedia wikis including Wikidata",
+    "name" : "wikipedia-ifttt-tool",
+    "title" : "Wikipedia & Wikidata RSS Feeds",
     "description" : "Use the tool to discover RSS for Wikipedia and Wikidata triggers without using IFTTT",
     "url" : "http://tools.wmflabs.org/ifttt-testing/ifttt/v1/rss-feeds",
     "keywords" : "rss-feeds, rss, feeds, wikipedia, wikidata",

--- a/toolinfo.json
+++ b/toolinfo.json
@@ -1,0 +1,9 @@
+{
+    "name" : "Wikipedia & Wikidata RSS Feeds",
+    "title" : "Featured content on Wikimedia wikis including Wikidata",
+    "description" : "Use the tool to discover RSS for Wikipedia and Wikidata triggers without using IFTTT",
+    "url" : "http://tools.wmflabs.org/ifttt-testing/ifttt/v1/rss-feeds",
+    "keywords" : "rss-feeds, rss, feeds, wikipedia, wikidata",
+    "author" : "Stephen Laport, Alangi Derick",
+    "repository" : "https://github.com/wikimedia/ifttt.git"
+}

--- a/toolinfo.json
+++ b/toolinfo.json
@@ -1,9 +1,0 @@
-{
-    "name" : "wikipedia-ifttt-tool",
-    "title" : "Wikipedia & Wikidata RSS Feeds",
-    "description" : "Use the tool to discover RSS for Wikipedia and Wikidata triggers without using IFTTT",
-    "url" : "http://tools.wmflabs.org/ifttt-testing/ifttt/v1/rss-feeds",
-    "keywords" : "rss-feeds, rss, feeds, wikipedia, wikidata",
-    "author" : "Stephen Laport, Alangi Derick",
-    "repository" : "https://github.com/wikimedia/ifttt.git"
-}


### PR DESCRIPTION
This patch removes / reduces external CDN sources of this application and restricts it only to those provided by tool labs.

Bug: T172609
Signed-off-by: Alangi Derick <alangiderick@gmail.com>